### PR TITLE
User firestore constructor fix

### DIFF
--- a/app/src/main/java/com/github/jovenpableo/friendtag/firebase/Users.java
+++ b/app/src/main/java/com/github/jovenpableo/friendtag/firebase/Users.java
@@ -118,7 +118,7 @@ public class Users {
     public void write(User user) {
         db.collection(TABLE_NAME)
                 .document(user.getUid())
-                .set(user.toMap())
+                .update(user.toMap())
                 .addOnSuccessListener(new OnSuccessListener<Void>() {
                     @Override
                     public void onSuccess(Void aVoid) {


### PR DESCRIPTION
This fixes the issue where if you didn't set your location in the emulator before opening the app it would delete your location, making it null.

Just switched from `set` to `update` for the firestore call which handles issues like that.

I don't know if that will work for new users, but one hurdle at a time.